### PR TITLE
Complete preliminary implementation of SBIT

### DIFF
--- a/playground/bw_grad.py
+++ b/playground/bw_grad.py
@@ -1,6 +1,9 @@
 import casadi.casadi as cs
 import numpy as np
 
+# This is not so interesting; check out playground/bw_grad_for_loop.py
+
+
 nx = 3
 nu = 3
 
@@ -86,7 +89,7 @@ ell_u_N_3 = ellu_py(xs[:, N-3], us[:, N-3])
 ell_x_N_2 = ellx_py(xs[:, N-2], us[:, N-2])
 nabla_Vf_N_3 = ell_u_N_3 + \
     jfu_py(xs[:, N-3], us[:, N-3], ell_x_N_2 +
-           jfx_py(xs[:, N-2], us[:, N-2], ell_x_N_1) + z_N_3)
+           jfx_py(xs[:, N-2], us[:, N-2], ell_x_N_1 + z_N_2))
 
 
 # But is this correct?

--- a/playground/bw_grad_for_loop.py
+++ b/playground/bw_grad_for_loop.py
@@ -1,0 +1,104 @@
+import casadi.casadi as cs
+import numpy as np
+
+# In this scirpt we test the correctness of the backward method
+# (using a for loop)
+
+nx = 3
+nu = 3
+N = 6
+
+x = cs.SX.sym('x', nx)
+u = cs.SX.sym('u', nu)
+d = cs.SX.sym('d', nx)
+f = cs.sin(x) + 2*u
+ell = 0.5 * (cs.dot(x, x) + cs.dot(u, u))
+vf = 20 * cs.dot(x, x)
+
+# Make Jacobians
+jfx = cs.jacobian(f, x) @ d
+jfu = cs.jacobian(f, u) @ d
+ellx = cs.jacobian(ell, x).T
+ellu = cs.jacobian(ell, u).T
+vfx = cs.jacobian(vf, x).T
+
+
+f_fun = cs.Function('f', [x, u], [f])
+jfx_fun = cs.Function('jfx', [x, u, d], [jfx])
+jfu_fun = cs.Function('jfu', [x, u, d], [jfu])
+ell_fun = cs.Function('ell', [x, u], [ell])
+ellx_fun = cs.Function('ellx', [x, u], [ellx])
+ellu_fun = cs.Function('ellu', [x, u], [ellu])
+vf_fun = cs.Function('vf', [x], [vf])
+vfx_fun = cs.Function('vfx', [x], [vfx])
+
+
+def f_py(x_, u_):
+    return f_fun(x_, u_).full()
+
+
+def jfx_py(x_, u_, d_):
+    return jfx_fun(x_, u_, d_).full()
+
+
+def jfu_py(x_, u_, d_):
+    return jfu_fun(x_, u_, d_).full()
+
+
+def ellx_py(x_, u_):
+    return ellx_fun(x_, u_).full()
+
+
+def ellu_py(x_, u_):
+    return ellu_fun(x_, u_).full()
+
+
+def vfx_py(x_):
+    return vfx_fun(x_).full()
+
+
+us = np.random.uniform(size=(nu, N))  # just a random sequence of inputs
+xs = np.zeros((nx, N+1))  # sequence of states
+xs[:, 0] = [1, 0, -1]  # some arbitrary initial state
+
+
+# ----------------------------------------------------
+# BACKWARD METHOD
+# ----------------------------------------------------
+# Simulate the system
+for i in range(N):
+    xs[:, i+1] = f_py(xs[:, i], us[:, i]).reshape(nx)
+
+grads_matrix = np.zeros((nu, N))
+w = vfx_py(xs[:, N])
+for j in range(1, N+1):
+    ellu_N_j = ellu_py(xs[:, N-j], us[:, N-j])
+    ellx_N_j = ellx_py(xs[:, N-j], us[:, N-j])
+    fu_N_j_w = jfu_py(xs[:, N-j], us[:, N-j], w)
+    fx_N_j_w = jfx_py(xs[:, N-j], us[:, N-j], w)
+    grad_N_j_VN = ellu_N_j + fu_N_j_w
+    w = ellx_N_j + fx_N_j_w
+    grads_matrix[:, N-j] = grad_N_j_VN.T
+
+# ----------------------------------------------------
+
+
+# Testing (comparison with CasADi's result)...
+VN = 0
+x = xs[:, 0]
+u_seq = cs.SX.sym('u_seq', nu, N)
+
+for i in range(N):
+    VN = VN + ell_fun(x, u_seq[:, i])
+    x = f_fun(x, u_seq[:, i])
+
+VN = VN + vf_fun(x)
+nabla_VN_u_N = cs.jacobian(VN, u_seq)
+nabla_VN_u_N_fun = cs.Function(
+    'nabla_VN_u_N', [u_seq], [nabla_VN_u_N])
+correct_nabla_VN_u = nabla_VN_u_N_fun(us)
+
+err = np.linalg.norm(
+    grads_matrix - correct_nabla_VN_u.reshape((nu, N)), np.inf)
+print(f"Error = {err}")
+assert (err < 1e-6)


### PR DESCRIPTION
## About

Complete preliminary implementation of SBIT with a for-loop (see details below).

- New file: `playground/bw_grad_for_loop.py` with brand new implementation
- Modified `playground/bw_grad.py`: testing SBIT at $t=N-2$ and $t=N-3$
- Fully tested (compared against Casadi's gradient computation)


## Details
The algorithm is as follows:

- Firstly, simulate the dynamical system over the prediction horizon and determine all states, $x_0, x_1, \ldots, x_N$
- $w \gets V_f^x$
- For $j=1,\ldots,N$:
  - $\nabla_{u_{N-j}}V_N{}\gets{}\ell^u_{N-j} + f^u_{N-j}w$
  - $w\gets\ell^x_{N-j} + f^x_{N-j}w$


## Associated issues 

- Closes #1 

