### PR TITLE
📦 Dependencies in generated Cargo.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Added
+
+- `CodeGenerationBuilder` can now attach extra Cargo dependencies to the
+  generated manifest, with optional versions written into the generated
+  `Cargo.toml`.
+
+
 ## 0.4.1 - 22-04-2026
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- `CodeGenerationBuilder` can now attach extra Cargo dependencies to the
-  generated manifest, with optional versions written into the generated
-  `Cargo.toml`.
+- `RustBackendConfig.with_additional_dependencies(...)` can now attach extra
+  Cargo dependencies to the generated manifest, with optional versions
+  written into the generated `Cargo.toml`.
+- `RustBackendConfig.with_header(...)` can now inject custom Rust code at the
+  top of generated `lib.rs`, after crate attributes such as `#![no_std]` and
+  `#![forbid(unsafe_code)]`.
 
 
 ## 0.4.1 - 22-04-2026

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `RustBackendConfig.with_header(...)` can now inject custom Rust code at the
   top of generated `lib.rs`, after crate attributes such as `#![no_std]` and
   `#![forbid(unsafe_code)]`.
+- `RustBackendConfig.with_header(...)` now treats the custom header 
+  as a small Jinja2 template, so expressions such as `{{ scalar_type }}`
+  are rendered before being inserted into generated Rust code.
 
 
 ## 0.4.1 - 22-04-2026

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 ## Code generation example
 
-[See documentation](https://qub-asl.github.io/gradgen/docs/basics/codegen)
+[Read the docs](https://qub-asl.github.io/gradgen/docs/category/learn)
 
 Here is an example where we will define the function 
 
@@ -108,7 +108,7 @@ See this complete [tutorial](https://qub-asl.github.io/gradgen/docs/basics/ocp) 
 
 ## Where to go next?
 
-See the [demos](./demos) and this more complete [documentation](https://qub-asl.github.io/gradgen/docs) for details.
+See the [demos](./demos) and this more complete [documentation](https://qub-asl.github.io/gradgen/docs/category/learn) for details.
 
 ## Show us some love!
 

--- a/docs/website/docs/basics/codegen.mdx
+++ b/docs/website/docs/basics/codegen.mdx
@@ -327,3 +327,27 @@ plan = f.cse(min_uses=2)
 where `min_uses` is the minimum number of times a symbolic 
 sub-expressions needs to be present in the overall symbolic 
 expression to be considered for elimination.
+
+## Dependencies 
+
+When generating code using `CodeGenerationBuilder` you can include additional 
+dependencies in the auto-generated `Cargo.toml`. This can be useful when 
+registering your [custom functions](/gradgen/docs/basics/custom) as we'll see later.
+
+Here is an example where we include the crates [`smallvec`](https://crates.io/crates/smallvec)
+v1.15 and the latest version of [`serde`](https://crates.io/crates/serde).
+
+```python
+builder = (
+    CodeGenerationBuilder()
+    .with_additional_dependencies([
+        "serde",
+        ("smallvec", "1.15"),
+    ])
+    .for_function(f)
+        .add_primal()
+        .done()
+)
+```
+
+If you omit a version, gradgen writes `*` in the generated `Cargo.toml` entry for that dependency.

--- a/docs/website/docs/basics/codegen.mdx
+++ b/docs/website/docs/basics/codegen.mdx
@@ -328,11 +328,13 @@ where `min_uses` is the minimum number of times a symbolic
 sub-expressions needs to be present in the overall symbolic 
 expression to be considered for elimination.
 
-## Dependencies 
+## Dependencies
 
-When generating code using `CodeGenerationBuilder` you can include additional 
-dependencies in the auto-generated `Cargo.toml`. This can be useful when 
-registering your [custom functions](/gradgen/docs/basics/custom) as we'll see later.
+When generating code using `CodeGenerationBuilder`, include extra Cargo
+dependencies and an optional Rust header on the `RustBackendConfig` you pass
+into `.with_backend_config(...)`. This keeps the manifest entries and the
+custom `lib.rs` prologue tied to the backend configuration that produces the
+crate.
 
 Here is an example where we include the crates [`smallvec`](https://crates.io/crates/smallvec)
 v1.15 and the latest version of [`serde`](https://crates.io/crates/serde).
@@ -340,10 +342,15 @@ v1.15 and the latest version of [`serde`](https://crates.io/crates/serde).
 ```python
 builder = (
     CodeGenerationBuilder()
-    .with_additional_dependencies([
-        "serde",
-        ("smallvec", "1.15"),
-    ])
+    .with_backend_config(
+        RustBackendConfig()
+        .with_crate_name("boom")
+        .with_header("use smallvec::{smallvec, SmallVec};")
+        .with_additional_dependencies([
+            ("serde", "*"),
+            ("smallvec", "1.15"),
+        ])
+    )
     .for_function(f)
         .add_primal()
         .done()
@@ -351,3 +358,13 @@ builder = (
 ```
 
 If you omit a version, gradgen writes `*` in the generated `Cargo.toml` entry for that dependency.
+
+Note that you can introduce a custom header into the auto-generated Rust code
+using `with_header`; this can be any custom Rust code you like. In the example 
+above we use it to introduce 
+
+```rust
+use smallvec::{smallvec, SmallVec};
+```
+
+You can even introduce your own Rust functions.

--- a/docs/website/publish.sh
+++ b/docs/website/publish.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 GIT_USER=alphaville \
-  CURRENT_BRANCH=master \
+  CURRENT_BRANCH=main \
   USE_SSH=true \
   yarn deploy
 

--- a/src/gradgen/_rust_codegen/builder.py
+++ b/src/gradgen/_rust_codegen/builder.py
@@ -177,6 +177,22 @@ class CodeGenerationBuilder:
         """Return a copy applying ``max_effort`` simplification to generated kernels."""
         return replace(self, simplification=max_effort)
 
+    def with_additional_dependencies(
+        self,
+        dependencies: (
+            list[str | tuple[str, str | None]]
+            | tuple[str | tuple[str, str | None], ...]
+        ),
+    ) -> CodeGenerationBuilder:
+        """Return a copy with extra Cargo dependencies included."""
+        from .config import RustBackendConfig
+
+        resolved_config = self.config or RustBackendConfig()
+        return replace(
+            self,
+            config=resolved_config.with_additional_dependencies(dependencies),
+        )
+
     def add_primal(self,
                    *,
                    include_states: bool = False) \

--- a/src/gradgen/_rust_codegen/builder.py
+++ b/src/gradgen/_rust_codegen/builder.py
@@ -177,37 +177,6 @@ class CodeGenerationBuilder:
         """Return a copy applying ``max_effort`` simplification to generated kernels."""
         return replace(self, simplification=max_effort)
 
-    def with_additional_dependencies(
-        self,
-        dependencies: (
-            list[str | tuple[str, str | None]]
-            | tuple[str | tuple[str, str | None], ...]
-        ),
-    ) -> CodeGenerationBuilder:
-        """Return a copy with extra Cargo dependencies included.
-
-        Args:
-            dependencies: Additional dependencies to include in the generated
-                ``Cargo.toml``. Each item may be either a dependency name, in
-                which case the version defaults to ``"*"`` in Cargo syntax, or
-                a ``(name, version)`` pair.
-
-        Returns:
-            A copy of the builder with the dependency list stored in the
-            active backend config.
-        """
-        from .config import RustBackendConfig
-
-        resolved_config = self.config or RustBackendConfig()
-        if not hasattr(resolved_config, "with_additional_dependencies"):
-            raise TypeError(
-                "with_additional_dependencies requires RustBackendConfig"
-            )
-        return replace(
-            self,
-            config=resolved_config.with_additional_dependencies(dependencies),
-        )
-
     def add_primal(self,
                    *,
                    include_states: bool = False) \

--- a/src/gradgen/_rust_codegen/builder.py
+++ b/src/gradgen/_rust_codegen/builder.py
@@ -188,6 +188,10 @@ class CodeGenerationBuilder:
         from .config import RustBackendConfig
 
         resolved_config = self.config or RustBackendConfig()
+        if not hasattr(resolved_config, "with_additional_dependencies"):
+            raise TypeError(
+                "with_additional_dependencies requires RustBackendConfig"
+            )
         return replace(
             self,
             config=resolved_config.with_additional_dependencies(dependencies),

--- a/src/gradgen/_rust_codegen/builder.py
+++ b/src/gradgen/_rust_codegen/builder.py
@@ -184,7 +184,18 @@ class CodeGenerationBuilder:
             | tuple[str | tuple[str, str | None], ...]
         ),
     ) -> CodeGenerationBuilder:
-        """Return a copy with extra Cargo dependencies included."""
+        """Return a copy with extra Cargo dependencies included.
+
+        Args:
+            dependencies: Additional dependencies to include in the generated
+                ``Cargo.toml``. Each item may be either a dependency name, in
+                which case the version defaults to ``"*"`` in Cargo syntax, or
+                a ``(name, version)`` pair.
+
+        Returns:
+            A copy of the builder with the dependency list stored in the
+            active backend config.
+        """
         from .config import RustBackendConfig
 
         resolved_config = self.config or RustBackendConfig()

--- a/src/gradgen/_rust_codegen/codegen.py
+++ b/src/gradgen/_rust_codegen/codegen.py
@@ -447,6 +447,7 @@ def generate_rust(
         backend_mode=resolved_config.backend_mode,
         scalar_type=resolved_config.scalar_type,
         math_library=resolved_math_library,
+        header=resolved_config.header,
         workspace_size=workspace_size,
         workspace_assert_line=_ws_assert,
         workspace_return_line=_ws_return,

--- a/src/gradgen/_rust_codegen/codegen.py
+++ b/src/gradgen/_rust_codegen/codegen.py
@@ -514,7 +514,7 @@ def create_multi_function_rust_project(
     dependency_lines = _render_cargo_dependency_lines(
         resolved_math_library,
         resolved_math_library_version,
-        resolved_config.additional_dependencies,
+        getattr(resolved_config, "additional_dependencies", ()),
     )
 
     project_dir = Path(path).expanduser().resolve()

--- a/src/gradgen/_rust_codegen/codegen.py
+++ b/src/gradgen/_rust_codegen/codegen.py
@@ -42,7 +42,7 @@ from .rendering import (
     _identify_direct_custom_output_marker,
     _reemit_direct_output_helper_call,
 )
-from .templates import _get_template
+from .templates import _get_template, _render_custom_rust_header
 from .validation import (
     resolve_backend_config as _resolve_backend_config,
     validate_backend_mode as _validate_backend_mode,
@@ -447,7 +447,13 @@ def generate_rust(
         backend_mode=resolved_config.backend_mode,
         scalar_type=resolved_config.scalar_type,
         math_library=resolved_math_library,
-        header=resolved_config.header,
+        header=_render_custom_rust_header(
+            resolved_config.header,
+            backend_mode=resolved_config.backend_mode,
+            scalar_type=resolved_config.scalar_type,
+            math_library=resolved_math_library,
+            emit_metadata_helpers=resolved_config.emit_metadata_helpers,
+        ),
         workspace_size=workspace_size,
         workspace_assert_line=_ws_assert,
         workspace_return_line=_ws_return,

--- a/src/gradgen/_rust_codegen/codegen.py
+++ b/src/gradgen/_rust_codegen/codegen.py
@@ -15,6 +15,7 @@ from .models import (
 )
 from .project_support import (
     _derive_python_function_name,
+    _render_cargo_dependency_lines,
     _render_metadata_json,
     _run_cargo_build,
     _try_run_cargo_fmt,
@@ -510,6 +511,11 @@ def create_multi_function_rust_project(
         if resolved_config.backend_mode == "no_std" else None
     resolved_math_library_version = "0.2" \
         if resolved_math_library == "libm" else None
+    dependency_lines = _render_cargo_dependency_lines(
+        resolved_math_library,
+        resolved_math_library_version,
+        resolved_config.additional_dependencies,
+    )
 
     project_dir = Path(path).expanduser().resolve()
     crate = sanitize_ident(resolved_config.crate_name or functions[0].name)
@@ -565,8 +571,7 @@ def create_multi_function_rust_project(
             crate_name=crate,
             backend_mode=resolved_config.backend_mode,
             scalar_type=resolved_config.scalar_type,
-            math_library=resolved_math_library,
-            math_library_version=resolved_math_library_version,
+            dependency_lines=dependency_lines,
         ),
         encoding="utf-8",
     )

--- a/src/gradgen/_rust_codegen/config.py
+++ b/src/gradgen/_rust_codegen/config.py
@@ -3,8 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
+from collections.abc import Iterable
 
-from .naming import validate_rust_ident
+from .naming import (
+    validate_cargo_dependency_name,
+    validate_rust_ident,
+)
 from .validation import (
     validate_backend_mode,
     validate_crate_name,
@@ -14,6 +18,7 @@ from .validation import (
 
 RustBackendMode = str
 RustScalarType = str
+CargoDependency = tuple[str, str | None]
 
 
 @dataclass(frozen=True, slots=True)
@@ -28,6 +33,7 @@ class RustBackendConfig:
     enable_python_interface: bool = False
     build_python_interface: bool = True
     build_crate: bool = False
+    additional_dependencies: tuple[CargoDependency, ...] = ()
 
     def with_backend_mode(self,
                           backend_mode: RustBackendMode) \
@@ -85,3 +91,33 @@ class RustBackendConfig:
         Return a copy with low-level crate compilation enabled or disabled.
         """
         return replace(self, build_crate=build_crate)
+
+    def with_additional_dependencies(
+        self,
+        dependencies: Iterable[str | CargoDependency],
+    ) -> RustBackendConfig:
+        """Return a copy with extra Cargo dependencies added.
+
+        Args:
+            dependencies: Additional dependencies to include in the generated
+                ``Cargo.toml``. Each item may be either a dependency name, in
+                which case the version defaults to ``"*"`` in Cargo syntax, or
+                a ``(name, version)`` pair.
+
+        Returns:
+            A copy of the config with the normalized dependency list.
+        """
+        normalized: list[CargoDependency] = []
+        for dependency in dependencies:
+            if isinstance(dependency, str):
+                name = dependency
+                version = None
+            else:
+                name, version = dependency
+            validate_cargo_dependency_name(name)
+            if version is not None and not isinstance(version, str):
+                raise TypeError(
+                    "Cargo dependency versions must be strings or None"
+                )
+            normalized.append((name, version))
+        return replace(self, additional_dependencies=tuple(normalized))

--- a/src/gradgen/_rust_codegen/config.py
+++ b/src/gradgen/_rust_codegen/config.py
@@ -66,7 +66,9 @@ class RustBackendConfig:
         Args:
             header: Extra Rust source to insert near the top of generated
                 ``src/lib.rs``. The text is written after crate attributes such
-                as ``#![no_std]`` and ``#![forbid(unsafe_code)]``.
+                as ``#![no_std]`` and ``#![forbid(unsafe_code)]``. The header
+                is rendered as a small Jinja2 template with variables such as
+                ``scalar_type``, ``backend_mode``, and ``math_library``.
 
         Returns:
             A copy of the config with the provided header text.

--- a/src/gradgen/_rust_codegen/config.py
+++ b/src/gradgen/_rust_codegen/config.py
@@ -29,6 +29,7 @@ class RustBackendConfig:
     scalar_type: RustScalarType = "f64"
     crate_name: str | None = None
     function_name: str | None = None
+    header: str | None = None
     emit_metadata_helpers: bool = True
     enable_python_interface: bool = False
     build_python_interface: bool = True
@@ -58,6 +59,19 @@ class RustBackendConfig:
         """Return a copy with a different generated Rust function name."""
         validate_rust_ident(function_name, label="function_name")
         return replace(self, function_name=function_name)
+
+    def with_header(self, header: str | None) -> RustBackendConfig:
+        """Return a copy with a custom Rust module header.
+
+        Args:
+            header: Extra Rust source to insert near the top of generated
+                ``src/lib.rs``. The text is written after crate attributes such
+                as ``#![no_std]`` and ``#![forbid(unsafe_code)]``.
+
+        Returns:
+            A copy of the config with the provided header text.
+        """
+        return replace(self, header=header)
 
     def with_emit_metadata_helpers(self,
                                    emit_metadata_helpers: bool) \

--- a/src/gradgen/_rust_codegen/generators/composed.py
+++ b/src/gradgen/_rust_codegen/generators/composed.py
@@ -107,6 +107,7 @@ def _generate_composed_primal_rust(
         backend_mode=resolved_config.backend_mode,
         scalar_type=resolved_config.scalar_type,
         math_library=resolved_math_library,
+        header=resolved_config.header,
         emit_metadata_helpers=resolved_config.emit_metadata_helpers,
     )
     helper_simplification = composed.simplification
@@ -366,6 +367,7 @@ def _generate_composed_jacobian_rust(
         backend_mode=resolved_config.backend_mode,
         scalar_type=resolved_config.scalar_type,
         math_library=resolved_math_library,
+        header=resolved_config.header,
         emit_metadata_helpers=resolved_config.emit_metadata_helpers,
     )
     helper_simplification = composed.simplification
@@ -739,6 +741,7 @@ def _generate_composed_joint_rust(
         backend_mode=resolved_config.backend_mode,
         scalar_type=resolved_config.scalar_type,
         math_library=resolved_math_library,
+        header=resolved_config.header,
         emit_metadata_helpers=resolved_config.emit_metadata_helpers,
     )
     helper_simplification = composed.simplification

--- a/src/gradgen/_rust_codegen/generators/map_zip.py
+++ b/src/gradgen/_rust_codegen/generators/map_zip.py
@@ -103,6 +103,7 @@ def _generate_batched_primal_rust(
         backend_mode=resolved_config.backend_mode,
         scalar_type=resolved_config.scalar_type,
         math_library=resolved_math_library,
+        header=resolved_config.header,
         emit_metadata_helpers=resolved_config.emit_metadata_helpers,
     )
     name = sanitize_ident(resolved_config.function_name or batched.name)
@@ -307,6 +308,7 @@ def _generate_batched_jacobian_rust(
         backend_mode=resolved_config.backend_mode,
         scalar_type=resolved_config.scalar_type,
         math_library=resolved_math_library,
+        header=resolved_config.header,
         emit_metadata_helpers=resolved_config.emit_metadata_helpers,
     )
     name = sanitize_ident(
@@ -556,6 +558,7 @@ def _generate_reduced_primal_rust(
         backend_mode=resolved_config.backend_mode,
         scalar_type=resolved_config.scalar_type,
         math_library=resolved_math_library,
+        header=resolved_config.header,
         emit_metadata_helpers=resolved_config.emit_metadata_helpers,
     )
     name = sanitize_ident(resolved_config.function_name or reduced.name)

--- a/src/gradgen/_rust_codegen/generators/rendering.py
+++ b/src/gradgen/_rust_codegen/generators/rendering.py
@@ -14,6 +14,7 @@ class KernelRenderContext:
     backend_mode: str
     scalar_type: str
     math_library: str | None
+    header: str | None
     emit_metadata_helpers: bool
 
 
@@ -23,11 +24,13 @@ def render_kernel_source(context: KernelRenderContext, /, **render_args) -> str:
     render_args.pop("backend_mode", None)
     render_args.pop("scalar_type", None)
     render_args.pop("math_library", None)
+    render_args.pop("header", None)
     render_args.pop("emit_metadata_helpers", None)
     return _get_template("lib.rs.j2").render(
         backend_mode=context.backend_mode,
         scalar_type=context.scalar_type,
         math_library=context.math_library,
+        header=context.header,
         emit_metadata_helpers=context.emit_metadata_helpers,
         **render_args,
     )

--- a/src/gradgen/_rust_codegen/generators/rendering.py
+++ b/src/gradgen/_rust_codegen/generators/rendering.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from ..templates import _get_template
+from ..templates import _get_template, _render_custom_rust_header
 
 
 @dataclass(frozen=True, slots=True)
@@ -16,6 +16,17 @@ class KernelRenderContext:
     math_library: str | None
     header: str | None
     emit_metadata_helpers: bool
+
+
+def render_custom_header(context: KernelRenderContext) -> str | None:
+    """Render the configured custom Rust header template."""
+    return _render_custom_rust_header(
+        context.header,
+        backend_mode=context.backend_mode,
+        scalar_type=context.scalar_type,
+        math_library=context.math_library,
+        emit_metadata_helpers=context.emit_metadata_helpers,
+    )
 
 
 def render_kernel_source(context: KernelRenderContext, /, **render_args) -> str:
@@ -30,7 +41,7 @@ def render_kernel_source(context: KernelRenderContext, /, **render_args) -> str:
         backend_mode=context.backend_mode,
         scalar_type=context.scalar_type,
         math_library=context.math_library,
-        header=context.header,
+        header=render_custom_header(context),
         emit_metadata_helpers=context.emit_metadata_helpers,
         **render_args,
     )

--- a/src/gradgen/_rust_codegen/generators/single_shooting.py
+++ b/src/gradgen/_rust_codegen/generators/single_shooting.py
@@ -189,6 +189,7 @@ def _generate_single_shooting_driver_rust(
         backend_mode=resolved_config.backend_mode,
         scalar_type=resolved_config.scalar_type,
         math_library=resolved_math_library,
+        header=resolved_config.header,
         emit_metadata_helpers=resolved_config.emit_metadata_helpers,
     )
 

--- a/src/gradgen/_rust_codegen/naming.py
+++ b/src/gradgen/_rust_codegen/naming.py
@@ -79,6 +79,15 @@ def validate_rust_ident(name: str | None, *, label: str) -> None:
         raise ValueError(f"{label} must not be a Rust keyword")
 
 
+def validate_cargo_dependency_name(name: str) -> None:
+    """Validate a dependency name written into ``Cargo.toml``."""
+    if not re.fullmatch(r"[A-Za-z0-9_][A-Za-z0-9_-]*", name):
+        raise ValueError(
+            "Cargo dependency names must match the pattern "
+            "[A-Za-z0-9_][A-Za-z0-9_-]*"
+        )
+
+
 def validate_unique_rust_names(
     names: list[tuple[str, str]],
     *,

--- a/src/gradgen/_rust_codegen/project.py
+++ b/src/gradgen/_rust_codegen/project.py
@@ -23,6 +23,7 @@ from .project_support import (
     _create_python_interface_project,
     _maybe_simplify_derivative_function,
     _render_metadata_json,
+    _render_cargo_dependency_lines,
     _run_cargo_build,
     _try_run_cargo_fmt,
 )
@@ -64,6 +65,11 @@ def create_rust_project(
     resolved_math_library_version = "0.2" \
         if resolved_math_library == "libm" \
         else None
+    dependency_lines = _render_cargo_dependency_lines(
+        resolved_math_library,
+        resolved_math_library_version,
+        resolved_config.additional_dependencies,
+    )
     codegen = generate_rust(
         function,
         config=resolved_config,
@@ -81,8 +87,7 @@ def create_rust_project(
             crate_name=crate,
             backend_mode=resolved_config.backend_mode,
             scalar_type=resolved_config.scalar_type,
-            math_library=resolved_math_library,
-            math_library_version=resolved_math_library_version,
+            dependency_lines=dependency_lines,
         ),
         encoding="utf-8",
     )

--- a/src/gradgen/_rust_codegen/project.py
+++ b/src/gradgen/_rust_codegen/project.py
@@ -68,7 +68,7 @@ def create_rust_project(
     dependency_lines = _render_cargo_dependency_lines(
         resolved_math_library,
         resolved_math_library_version,
-        resolved_config.additional_dependencies,
+        getattr(resolved_config, "additional_dependencies", ()),
     )
     codegen = generate_rust(
         function,

--- a/src/gradgen/_rust_codegen/project_support.py
+++ b/src/gradgen/_rust_codegen/project_support.py
@@ -21,7 +21,7 @@ from .models import (
     RustPythonInterfaceProjectResult,
 )
 from .naming import sanitize_ident
-from .templates import _get_template
+from .templates import _get_template, _render_custom_rust_header
 from .validation import validate_unique_rust_names
 
 
@@ -379,9 +379,16 @@ def _render_multi_function_lib(
     sections: list[str] = []
     seen_private_helpers: set[str] = set()
     seen_generated_module_sections: set[str] = set()
+    rendered_header = _render_custom_rust_header(
+        config.header,
+        backend_mode=config.backend_mode,
+        scalar_type=config.scalar_type,
+        math_library="libm" if config.backend_mode == "no_std" else None,
+        emit_metadata_helpers=config.emit_metadata_helpers,
+    )
     header_sections = tuple(
-        _split_module_sections(config.header)
-        if config.header else ()
+        _split_module_sections(rendered_header)
+        if rendered_header else ()
     )
     header_emitted = False
     if config.backend_mode == "no_std":

--- a/src/gradgen/_rust_codegen/project_support.py
+++ b/src/gradgen/_rust_codegen/project_support.py
@@ -156,6 +156,29 @@ def _run_cargo_build(project_dir: Path) -> None:
         ) from exc
 
 
+def _render_cargo_dependency_lines(
+    math_library: str | None,
+    math_library_version: str | None,
+    additional_dependencies: tuple[tuple[str, str | None], ...],
+) -> tuple[str, ...]:
+    """Return rendered Cargo dependency lines for a generated crate."""
+    lines: list[str] = []
+    seen: set[str] = set()
+
+    def add_dependency(name: str, version: str | None) -> None:
+        if name in seen:
+            raise ValueError(f"duplicate Cargo dependency {name!r}")
+        seen.add(name)
+        rendered_version = version if version is not None else "*"
+        lines.append(f'{name} = {json.dumps(rendered_version)}')
+
+    if math_library is not None:
+        add_dependency(math_library, math_library_version)
+    for dependency_name, dependency_version in additional_dependencies:
+        add_dependency(dependency_name, dependency_version)
+    return tuple(lines)
+
+
 def _derive_python_function_name(function_name: str,
                                  crate_name: str | None) -> str:
     """Derive the public Python name from a generated Rust symbol name."""

--- a/src/gradgen/_rust_codegen/project_support.py
+++ b/src/gradgen/_rust_codegen/project_support.py
@@ -316,6 +316,61 @@ def _generated_module_section_key(section: str) -> str | None:
     return None
 
 
+def _split_module_sections(source: str) -> list[str]:
+    """Split generated Rust source into normalized top-level sections."""
+    if source.startswith("#![no_std]\n\n"):
+        source = source[len("#![no_std]\n\n"):]
+    elif source.startswith("#![no_std]\n"):
+        source = source[len("#![no_std]\n"):]
+    return [part.rstrip() for part in source.split("\n\n") if part.strip()]
+
+
+def _normalize_header_sections(
+    sections: list[str],
+    header_sections: tuple[str, ...],
+    *,
+    header_emitted: bool,
+) -> tuple[list[str], bool]:
+    """Remove or keep the configured custom header at the front."""
+    if not sections or not header_sections:
+        return sections, header_emitted
+
+    header_start = 0
+    if _generated_module_section_key(sections[0]) == "module_header":
+        header_start = 1
+    header_end = header_start + len(header_sections)
+    if tuple(sections[header_start:header_end]) != header_sections:
+        return sections, header_emitted
+    if header_emitted:
+        return (
+            sections[:header_start] + sections[header_end:],
+            True,
+        )
+    return sections, True
+
+
+def _should_include_module_section(
+    section: str,
+    *,
+    seen_private_helpers: set[str],
+    seen_generated_module_sections: set[str],
+) -> bool:
+    """Return whether a multi-function module section should be emitted."""
+    module_key = _generated_module_section_key(section)
+    if module_key is not None:
+        if module_key in seen_generated_module_sections:
+            return False
+        seen_generated_module_sections.add(module_key)
+
+    helper_key = _private_helper_section_key(section)
+    if helper_key is not None:
+        if helper_key in seen_private_helpers:
+            return False
+        seen_private_helpers.add(helper_key)
+
+    return True
+
+
 def _render_multi_function_lib(
     codegens: tuple[RustCodegenResult, ...],
     config: RustBackendConfig,
@@ -324,52 +379,28 @@ def _render_multi_function_lib(
     sections: list[str] = []
     seen_private_helpers: set[str] = set()
     seen_generated_module_sections: set[str] = set()
-    header = config.header.rstrip() if config.header else None
+    header_sections = tuple(
+        _split_module_sections(config.header)
+        if config.header else ()
+    )
     header_emitted = False
     if config.backend_mode == "no_std":
         sections.append("#![no_std]")
 
     for codegen in codegens:
-        source = codegen.source
-        if source.startswith("#![no_std]\n\n"):
-            source = source[len("#![no_std]\n\n"):]
-        elif source.startswith("#![no_std]\n"):
-            source = source[len("#![no_std]\n"):]
-        codegen_sections = [
-            part.rstrip()
-            for part in source.split("\n\n")
-            if part.strip()
-        ]
-        if header is not None and codegen_sections:
-            first_section = codegen_sections[0]
-            if first_section == header:
-                if header_emitted:
-                    codegen_sections = codegen_sections[1:]
-                else:
-                    header_emitted = True
-            elif first_section.endswith(header):
-                header_prefix = first_section[: -len(header)].rstrip()
-                if header_prefix.endswith("\n"):
-                    header_prefix = header_prefix[:-1].rstrip()
-                if header_emitted:
-                    codegen_sections[0] = header_prefix
-                else:
-                    codegen_sections[0] = header_prefix
-                    codegen_sections.insert(1, header)
-                    header_emitted = True
-
+        codegen_sections = _split_module_sections(codegen.source)
+        codegen_sections, header_emitted = _normalize_header_sections(
+            codegen_sections,
+            header_sections,
+            header_emitted=header_emitted,
+        )
         for section in codegen_sections:
-            module_key = _generated_module_section_key(section)
-            if module_key is not None:
-                if module_key in seen_generated_module_sections:
-                    continue
-                seen_generated_module_sections.add(module_key)
-            helper_key = _private_helper_section_key(section)
-            if helper_key is not None:
-                if helper_key in seen_private_helpers:
-                    continue
-                seen_private_helpers.add(helper_key)
-            sections.append(section)
+            if _should_include_module_section(
+                section,
+                seen_private_helpers=seen_private_helpers,
+                seen_generated_module_sections=seen_generated_module_sections,
+            ):
+                sections.append(section)
 
     rendered = "\n\n".join(section for section in sections if section)
     return rendered if rendered.endswith("\n") else f"{rendered}\n"

--- a/src/gradgen/_rust_codegen/project_support.py
+++ b/src/gradgen/_rust_codegen/project_support.py
@@ -324,6 +324,8 @@ def _render_multi_function_lib(
     sections: list[str] = []
     seen_private_helpers: set[str] = set()
     seen_generated_module_sections: set[str] = set()
+    header = config.header.rstrip() if config.header else None
+    header_emitted = False
     if config.backend_mode == "no_std":
         sections.append("#![no_std]")
 
@@ -333,8 +335,30 @@ def _render_multi_function_lib(
             source = source[len("#![no_std]\n\n"):]
         elif source.startswith("#![no_std]\n"):
             source = source[len("#![no_std]\n"):]
-        for section in (part.rstrip()
-                        for part in source.split("\n\n") if part.strip()):
+        codegen_sections = [
+            part.rstrip()
+            for part in source.split("\n\n")
+            if part.strip()
+        ]
+        if header is not None and codegen_sections:
+            first_section = codegen_sections[0]
+            if first_section == header:
+                if header_emitted:
+                    codegen_sections = codegen_sections[1:]
+                else:
+                    header_emitted = True
+            elif first_section.endswith(header):
+                header_prefix = first_section[: -len(header)].rstrip()
+                if header_prefix.endswith("\n"):
+                    header_prefix = header_prefix[:-1].rstrip()
+                if header_emitted:
+                    codegen_sections[0] = header_prefix
+                else:
+                    codegen_sections[0] = header_prefix
+                    codegen_sections.insert(1, header)
+                    header_emitted = True
+
+        for section in codegen_sections:
             module_key = _generated_module_section_key(section)
             if module_key is not None:
                 if module_key in seen_generated_module_sections:

--- a/src/gradgen/_rust_codegen/templates.py
+++ b/src/gradgen/_rust_codegen/templates.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from jinja2 import Environment, FileSystemLoader, select_autoescape
+from jinja2 import (
+    Environment,
+    FileSystemLoader,
+    StrictUndefined,
+    TemplateError,
+    select_autoescape,
+)
 
 
 def _template_environment() -> Environment:
@@ -20,6 +26,38 @@ def _template_environment() -> Environment:
         ),
         trim_blocks=True,
         lstrip_blocks=True,
+    )
+
+
+def _render_inline_template(template_source: str, /, **context: object) -> str:
+    """Render a Jinja2 template string used inside generated artifacts."""
+    environment = _template_environment()
+    environment.undefined = StrictUndefined
+    try:
+        return environment.from_string(template_source).render(**context)
+    except TemplateError as exc:
+        raise ValueError(
+            "failed to render the custom Rust header template"
+        ) from exc
+
+
+def _render_custom_rust_header(
+    header: str | None,
+    *,
+    backend_mode: str,
+    scalar_type: str,
+    math_library: str | None,
+    emit_metadata_helpers: bool,
+) -> str | None:
+    """Render a custom Rust header template using kernel render context."""
+    if header is None:
+        return None
+    return _render_inline_template(
+        header,
+        backend_mode=backend_mode,
+        scalar_type=scalar_type,
+        math_library=math_library,
+        emit_metadata_helpers=emit_metadata_helpers,
     )
 
 

--- a/src/gradgen/templates/Cargo.toml.j2
+++ b/src/gradgen/templates/Cargo.toml.j2
@@ -6,10 +6,9 @@ description = "Generated gradgen crate using {{ scalar_type }}"
 
 [lib]
 path = "src/lib.rs"
-{% if backend_mode == "no_std" %}
-
+{% if dependency_lines %}
 [dependencies]
-{% if math_library %}
-{{ math_library }} = "{{ math_library_version }}"
-{% endif %}
+{% for dependency_line in dependency_lines %}
+{{ dependency_line }}
+{% endfor %}
 {% endif %}

--- a/src/gradgen/templates/lib.rs.j2
+++ b/src/gradgen/templates/lib.rs.j2
@@ -5,6 +5,10 @@
 #![forbid(unsafe_code)]
 {% endif %}
 
+{% if function_index == 0 and header -%}
+{{ header.rstrip() }}
+
+{% endif -%}
 {% if function_index == 0 and backend_mode == "no_std" and math_library == "micromath" -%}
 extern crate micromath as micromath_dep;
 

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -1,7 +1,6 @@
 import unittest
 
 from gradgen._rust_codegen.builder import CodeGenerationBuilder
-from gradgen._rust_codegen.config import RustBackendConfig
 
 
 class BuilderTests(unittest.TestCase):
@@ -9,16 +8,5 @@ class BuilderTests(unittest.TestCase):
         builder = CodeGenerationBuilder()
         self.assertIsNotNone(builder)
 
-    def test_builder_can_store_additional_dependencies(self) -> None:
-        builder = (
-            CodeGenerationBuilder()
-            .with_backend_config(RustBackendConfig().with_crate_name("demo"))
-            .with_additional_dependencies(
-                ["serde", ("smallvec", "1.13")]
-            )
-        )
-        assert builder.config is not None
-        self.assertEqual(
-            builder.config.additional_dependencies,
-            (("serde", None), ("smallvec", "1.13")),
-        )
+    def test_builder_has_no_additional_dependencies_helper(self) -> None:
+        self.assertFalse(hasattr(CodeGenerationBuilder(), "with_additional_dependencies"))

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -1,9 +1,24 @@
 import unittest
 
 from gradgen._rust_codegen.builder import CodeGenerationBuilder
+from gradgen._rust_codegen.config import RustBackendConfig
 
 
 class BuilderTests(unittest.TestCase):
     def test_builder_is_instantiable(self) -> None:
         builder = CodeGenerationBuilder()
         self.assertIsNotNone(builder)
+
+    def test_builder_can_store_additional_dependencies(self) -> None:
+        builder = (
+            CodeGenerationBuilder()
+            .with_backend_config(RustBackendConfig().with_crate_name("demo"))
+            .with_additional_dependencies(
+                ["serde", ("smallvec", "1.13")]
+            )
+        )
+        assert builder.config is not None
+        self.assertEqual(
+            builder.config.additional_dependencies,
+            (("serde", None), ("smallvec", "1.13")),
+        )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,6 +10,7 @@ class RustBackendConfigTests(unittest.TestCase):
         self.assertEqual(config.scalar_type, "f64")
         self.assertIsNone(config.crate_name)
         self.assertIsNone(config.function_name)
+        self.assertIsNone(config.header)
         self.assertTrue(config.emit_metadata_helpers)
         self.assertFalse(config.enable_python_interface)
         self.assertTrue(config.build_python_interface)
@@ -34,3 +35,9 @@ class RustBackendConfigTests(unittest.TestCase):
             config.additional_dependencies,
             (("serde", None), ("smallvec", "1.13")),
         )
+
+    def test_header_can_be_set(self) -> None:
+        config = RustBackendConfig().with_header(
+            "use smallvec::{smallvec};"
+        )
+        self.assertEqual(config.header, "use smallvec::{smallvec};")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -25,3 +25,12 @@ class RustBackendConfigTests(unittest.TestCase):
             .with_build_crate(True)
         self.assertFalse(config.build_python_interface)
         self.assertTrue(config.build_crate)
+
+    def test_additional_dependencies_are_normalized(self) -> None:
+        config = RustBackendConfig().with_additional_dependencies(
+            ["serde", ("smallvec", "1.13")]
+        )
+        self.assertEqual(
+            config.additional_dependencies,
+            (("serde", None), ("smallvec", "1.13")),
+        )

--- a/tests/test_project_support.py
+++ b/tests/test_project_support.py
@@ -113,3 +113,51 @@ class ProjectSupportTests(unittest.TestCase):
             RustBackendConfig(header="use smallvec::{smallvec, SmallVec};"),
         )
         self.assertEqual(rendered.count("use smallvec::{smallvec, SmallVec};"), 1)
+
+    def test_render_multi_function_lib_deduplicates_multisection_header(
+        self,
+    ) -> None:
+        header = "use smallvec::{smallvec, SmallVec};\n\nfn helper() {}"
+        codegen_a = RustCodegenResult(
+            source=(
+                "#![forbid(unsafe_code)]\n\n"
+                "use smallvec::{smallvec, SmallVec};\n\n"
+                "fn helper() {}\n\n"
+                "pub fn a() {}\n"
+            ),
+            python_name="a",
+            function_name="a",
+            workspace_size=0,
+            input_names=(),
+            input_sizes=(),
+            output_names=(),
+            output_sizes=(),
+            backend_mode="std",
+            scalar_type="f64",
+            math_library=None,
+        )
+        codegen_b = RustCodegenResult(
+            source=(
+                "#![forbid(unsafe_code)]\n\n"
+                "use smallvec::{smallvec, SmallVec};\n\n"
+                "fn helper() {}\n\n"
+                "pub fn b() {}\n"
+            ),
+            python_name="b",
+            function_name="b",
+            workspace_size=0,
+            input_names=(),
+            input_sizes=(),
+            output_names=(),
+            output_sizes=(),
+            backend_mode="std",
+            scalar_type="f64",
+            math_library=None,
+        )
+
+        rendered = _render_multi_function_lib(
+            (codegen_a, codegen_b),
+            RustBackendConfig(header=header),
+        )
+        self.assertEqual(rendered.count("use smallvec::{smallvec, SmallVec};"), 1)
+        self.assertEqual(rendered.count("fn helper() {}"), 1)

--- a/tests/test_project_support.py
+++ b/tests/test_project_support.py
@@ -73,6 +73,43 @@ class ProjectSupportTests(unittest.TestCase):
             math_library="libm",
         )
 
-        rendered = _render_multi_function_lib((codegen_a, codegen_b), RustBackendConfig(backend_mode="no_std"))
+        rendered = _render_multi_function_lib(
+            (codegen_a, codegen_b),
+            RustBackendConfig(backend_mode="no_std"),
+        )
         self.assertTrue(rendered.startswith("#![no_std]"))
         self.assertEqual(rendered.count("fn helper() {}"), 1)
+
+    def test_render_multi_function_lib_deduplicates_custom_header(self) -> None:
+        codegen_a = RustCodegenResult(
+            source="use smallvec::{smallvec, SmallVec};\n\npub fn a() {}\n",
+            python_name="a",
+            function_name="a",
+            workspace_size=0,
+            input_names=(),
+            input_sizes=(),
+            output_names=(),
+            output_sizes=(),
+            backend_mode="std",
+            scalar_type="f64",
+            math_library=None,
+        )
+        codegen_b = RustCodegenResult(
+            source="use smallvec::{smallvec, SmallVec};\n\npub fn b() {}\n",
+            python_name="b",
+            function_name="b",
+            workspace_size=0,
+            input_names=(),
+            input_sizes=(),
+            output_names=(),
+            output_sizes=(),
+            backend_mode="std",
+            scalar_type="f64",
+            math_library=None,
+        )
+
+        rendered = _render_multi_function_lib(
+            (codegen_a, codegen_b),
+            RustBackendConfig(header="use smallvec::{smallvec, SmallVec};"),
+        )
+        self.assertEqual(rendered.count("use smallvec::{smallvec, SmallVec};"), 1)

--- a/tests/test_project_support.py
+++ b/tests/test_project_support.py
@@ -161,3 +161,40 @@ class ProjectSupportTests(unittest.TestCase):
         )
         self.assertEqual(rendered.count("use smallvec::{smallvec, SmallVec};"), 1)
         self.assertEqual(rendered.count("fn helper() {}"), 1)
+
+    def test_render_multi_function_lib_deduplicates_templated_header(self) -> None:
+        header = "type Scalar = {{ scalar_type }};"
+        rendered_header = "type Scalar = f32;"
+        codegen_a = RustCodegenResult(
+            source=f"{rendered_header}\n\npub fn a() {{}}\n",
+            python_name="a",
+            function_name="a",
+            workspace_size=0,
+            input_names=(),
+            input_sizes=(),
+            output_names=(),
+            output_sizes=(),
+            backend_mode="std",
+            scalar_type="f32",
+            math_library=None,
+        )
+        codegen_b = RustCodegenResult(
+            source=f"{rendered_header}\n\npub fn b() {{}}\n",
+            python_name="b",
+            function_name="b",
+            workspace_size=0,
+            input_names=(),
+            input_sizes=(),
+            output_names=(),
+            output_sizes=(),
+            backend_mode="std",
+            scalar_type="f32",
+            math_library=None,
+        )
+
+        rendered = _render_multi_function_lib(
+            (codegen_a, codegen_b),
+            RustBackendConfig(scalar_type="f32", header=header),
+        )
+        self.assertEqual(rendered.count("type Scalar = f32;"), 1)
+        self.assertNotIn("{{ scalar_type }}", rendered)

--- a/tests/test_rust_codegen.py
+++ b/tests/test_rust_codegen.py
@@ -3468,6 +3468,62 @@ mod tests {{
             self.assertIn(header_text, lib_text)
             self.assertIn("fn helper() {}", lib_text)
 
+    def test_project_renders_templated_custom_header(self) -> None:
+        x = SX.sym("x")
+        f = Function(
+            "header_template_kernel",
+            [x],
+            [x * x],
+            input_names=["x"],
+            output_names=["y"],
+        )
+        config = (
+            RustBackendConfig()
+            .with_backend_mode("no_std")
+            .with_scalar_type("f32")
+            .with_header(
+                "/// Square\n"
+                "fn sq(x: {{ scalar_type }}) -> {{ scalar_type }} {\n"
+                "    x * x\n"
+                "}"
+            )
+        )
+
+        with TemporaryDirectory() as tmpdir:
+            project = create_rust_project(
+                f,
+                Path(tmpdir) / "header_template_kernel",
+                config=config,
+            )
+
+            lib_text = project.lib_rs.read_text(encoding="utf-8")
+            self.assertIn("fn sq(x: f32) -> f32", lib_text)
+            self.assertNotIn("{{ scalar_type }}", lib_text)
+
+    def test_project_rejects_invalid_templated_custom_header(self) -> None:
+        x = SX.sym("x")
+        f = Function(
+            "invalid_header_template_kernel",
+            [x],
+            [x],
+            input_names=["x"],
+            output_names=["y"],
+        )
+        config = RustBackendConfig().with_header(
+            "type Scalar = {{ missing_scalar_type }};"
+        )
+
+        with TemporaryDirectory() as tmpdir:
+            with self.assertRaisesRegex(
+                ValueError,
+                "failed to render the custom Rust header template",
+            ):
+                create_rust_project(
+                    f,
+                    Path(tmpdir) / "invalid_header_template_kernel",
+                    config=config,
+                )
+
     def test_invalid_backend_mode_is_rejected(self) -> None:
         x = SX.sym("x")
         f = Function("f", [x], [x], input_names=["x"], output_names=["y"])

--- a/tests/test_rust_codegen.py
+++ b/tests/test_rust_codegen.py
@@ -1383,10 +1383,11 @@ mod single_shooting_multi_u_tests {{
             project = (
                 CodeGenerationBuilder()
                 .with_backend_config(
-                    RustBackendConfig().with_crate_name("deps_demo")
-                )
-                .with_additional_dependencies(
-                    ["serde", ("smallvec", "1.13")]
+                    RustBackendConfig()
+                    .with_crate_name("deps_demo")
+                    .with_additional_dependencies(
+                        ["serde", ("smallvec", "1.13")]
+                    )
                 )
                 .for_function(f)
                 .add_primal()
@@ -3429,6 +3430,43 @@ mod tests {{
                     )
                 raise
             self.assertEqual(completed.returncode, 0)
+
+    def test_no_std_project_inserts_custom_header_after_crate_attrs(
+        self,
+    ) -> None:
+        x = SX.sym("x")
+        f = Function(
+            "header_kernel",
+            [x],
+            [x.sin()],
+            input_names=["x"],
+            output_names=["y"],
+        )
+        config = (
+            RustBackendConfig()
+            .with_backend_mode("no_std")
+            .with_header(
+                "use smallvec::{smallvec, SmallVec};\n\nfn helper() {}"
+            )
+        )
+
+        with TemporaryDirectory() as tmpdir:
+            project = create_rust_project(
+                f,
+                Path(tmpdir) / "header_kernel",
+                config=config,
+            )
+
+            lib_text = project.lib_rs.read_text(encoding="utf-8")
+            header_text = (
+                "#![forbid(unsafe_code)]\n\n"
+                "use smallvec::{smallvec, SmallVec};"
+            )
+            self.assertTrue(
+                lib_text.startswith("#![no_std]\n#![forbid(unsafe_code)]")
+            )
+            self.assertIn(header_text, lib_text)
+            self.assertIn("fn helper() {}", lib_text)
 
     def test_invalid_backend_mode_is_rejected(self) -> None:
         x = SX.sym("x")

--- a/tests/test_rust_codegen.py
+++ b/tests/test_rust_codegen.py
@@ -1367,6 +1367,38 @@ mod single_shooting_multi_u_tests {{
             self.assertIn('version = "0.1.0"', first_pyproject)
             self.assertIn('version = "0.2.0"', second_pyproject)
 
+    def test_builder_additional_dependencies_are_written_to_cargo_toml(
+        self,
+    ) -> None:
+        x = SXVector.sym("x", 1)
+        f = Function(
+            "energy",
+            [x],
+            [x[0] + 1.0],
+            input_names=["x"],
+            output_names=["y"],
+        )
+
+        with TemporaryDirectory() as tmpdir:
+            project = (
+                CodeGenerationBuilder()
+                .with_backend_config(
+                    RustBackendConfig().with_crate_name("deps_demo")
+                )
+                .with_additional_dependencies(
+                    ["serde", ("smallvec", "1.13")]
+                )
+                .for_function(f)
+                .add_primal()
+                .done()
+                .build(Path(tmpdir))
+            )
+
+            cargo_text = project.cargo_toml.read_text(encoding="utf-8")
+            self.assertIn("[dependencies]", cargo_text)
+            self.assertIn('serde = "*"', cargo_text)
+            self.assertIn('smallvec = "1.13"', cargo_text)
+
     def test_create_rust_project_can_build_generated_crate(self) -> None:
         x = SXVector.sym("x", 2)
         w = SXVector.sym("w", 1)


### PR DESCRIPTION
## Main changes

- `RustBackendConfig.with_additional_dependencies(...)` can now attach extra Cargo dependencies to the generated manifest, with optional versions written into the generated `Cargo.toml`.
- `RustBackendConfig.with_header(...)` can now inject custom Rust code at the top of generated `lib.rs`, after crate attributes such as `#![no_std]` and  `#![forbid(unsafe_code)]`.

## Associated issues

- Closes #67 